### PR TITLE
Update switch_trains.rb

### DIFF
--- a/assets/app/view/game/switch_trains.rb
+++ b/assets/app/view/game/switch_trains.rb
@@ -8,6 +8,7 @@ module View
     class SwitchTrains < Snabberb::Component
       include Actionable
       include AlternateCorporations
+      include Lib::Settings
 
       def render
         @step = @game.round.active_step


### PR DESCRIPTION
Add the include for Lib::Settings to get the right functions available to use the color_for function.  I checked all the other places, they are all correct.

Fixes #10378

<!--

Please minimize the amount of changes to shared `lib/engine` code, if possible

If you are implementing a new game, please break up the changes into multiple PRs for ease of review.

-->

### Before clicking "Create"

- [X] Branch is derived from the latest `master`
- [X] Add the `pins` label if this change will break existing games
- [X] Code passes linter with `docker compose exec rack rubocop -a`
- [X] Tests pass cleanly with `docker compose exec rack rake`

### Implementation Notes

* **Explanation of Change**

    Add the right includes to ensure `color_for` is available.

* **Screenshots**

    game 151777 rendering at latest action
     ![image](https://github.com/andrewzwicky/18xx/assets/5263073/8c64484a-a228-4e37-8ba9-6c58e263eee6)


* **Any Assumptions / Hacks**
